### PR TITLE
Allow use of IAM role or session token

### DIFF
--- a/0.1/files/main.sh
+++ b/0.1/files/main.sh
@@ -9,13 +9,14 @@ S3CMD_PATH=/opt/s3cmd/s3cmd
 # Check for required parameters
 #
 if [ -z "${aws_key}" ]; then
-    echo "ERROR: The environment variable key is not set."
-    exit 1
+    echo "ERROR: The environment variable key is not set. Attempting to create empty creds file to use role."
+    aws_key=""
 fi
 
 if [ -z "${aws_secret}" ]; then
     echo "ERROR: The environment variable secret is not set."
-    exit 1
+    aws_secret=""
+    security_token=""
 fi
 
 if [ -z "${cmd}" ]; then

--- a/0.1/files/main.sh
+++ b/0.1/files/main.sh
@@ -28,8 +28,12 @@ fi
 # Replace key and secret in the /.s3cfg file with the one the user provided
 #
 echo "" >> /.s3cfg
-echo "access_key=${aws_key}" >> /.s3cfg
-echo "secret_key=${aws_secret}" >> /.s3cfg
+echo "access_key = ${aws_key}" >> /.s3cfg
+echo "secret_key = ${aws_secret}" >> /.s3cfg
+
+if [ -z "${security_token}" ]; then
+    echo "security_token = ${aws_security_token}" >> /.s3cfg
+fi
 
 #
 # Add region base host if it exist in the env vars

--- a/0.1/files/main.sh
+++ b/0.1/files/main.sh
@@ -9,12 +9,12 @@ S3CMD_PATH=/opt/s3cmd/s3cmd
 # Check for required parameters
 #
 if [ -z "${aws_key}" ]; then
-    echo "ERROR: The environment variable key is not set. Attempting to create empty creds file to use role."
+    echo "The environment variable key is not set. Attempting to create empty creds file to use role."
     aws_key=""
 fi
 
 if [ -z "${aws_secret}" ]; then
-    echo "ERROR: The environment variable secret is not set."
+    echo "The environment variable secret is not set."
     aws_secret=""
     security_token=""
 fi

--- a/0.1/files/main.sh
+++ b/0.1/files/main.sh
@@ -9,14 +9,13 @@ S3CMD_PATH=/opt/s3cmd/s3cmd
 # Check for required parameters
 #
 if [ -z "${aws_key}" ]; then
-    echo "The environment variable key is not set. Attempting to create empty creds file to use role."
-    aws_key=""
+    echo "ERROR: The environment variable key is not set."
+    exit 1
 fi
 
 if [ -z "${aws_secret}" ]; then
-    echo "The environment variable secret is not set."
-    aws_secret=""
-    security_token=""
+    echo "ERROR: The environment variable secret is not set."
+    exit 1
 fi
 
 if [ -z "${cmd}" ]; then
@@ -28,12 +27,8 @@ fi
 # Replace key and secret in the /.s3cfg file with the one the user provided
 #
 echo "" >> /.s3cfg
-echo "access_key = ${aws_key}" >> /.s3cfg
-echo "secret_key = ${aws_secret}" >> /.s3cfg
-
-if [ -z "${security_token}" ]; then
-    echo "security_token = ${aws_security_token}" >> /.s3cfg
-fi
+echo "access_key=${aws_key}" >> /.s3cfg
+echo "secret_key=${aws_secret}" >> /.s3cfg
 
 #
 # Add region base host if it exist in the env vars

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ You can find an automated build of this container on the Docker Hub: https://hub
 
 # Usage Instruction
 
+## Optional inputs
+If access for your instance, task, etc. is configured through an IAM role you may omit the following inputs:
+
+    AWS_KEY=<YOUR AWS KEY>
+    AWS_SECRET=<YOUR AWS SECRET>  
+
 ## Copy from local to S3:
 
     AWS_KEY=<YOUR AWS KEY>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 docker-s3cmd
 ============
-[![GitHub forks](https://img.shields.io/github/forks/zambien/docker-s3cmd.svg)](https://github.com/zambien/docker-s3cmd/network)
-[![GitHub stars](https://img.shields.io/github/stars/zambien/docker-s3cmd.svg)](https://github.com/zambien/docker-s3cmd/stargazers)
-[![GitHub issues](https://img.shields.io/github/issues/zambien/docker-s3cmd.svg)](https://github.com/zambien/docker-s3cmd/issues)
-[![Twitter](https://img.shields.io/twitter/url/https/github.com/zambien/docker-s3cmd.svg?style=social)](https://twitter.com/intent/tweet?text=S3cmd%20in%20a%20%40Docker%20container:&url=https://github.com/zambien/docker-s3cmd)
-[![Docker Pulls](https://img.shields.io/docker/pulls/zambien/docker-s3cmd.svg)](https://hub.docker.com/r/zambien/docker-s3cmd/)
-[![Docker Stars](https://img.shields.io/docker/stars/zambien/docker-s3cmd.svg)](https://hub.docker.com/r/zambien/docker-s3cmd/)
+[![GitHub forks](https://img.shields.io/github/forks/sekka1/docker-s3cmd.svg)](https://github.com/sekka1/docker-s3cmd/network)
+[![GitHub stars](https://img.shields.io/github/stars/sekka1/docker-s3cmd.svg)](https://github.com/sekka1/docker-s3cmd/stargazers)
+[![GitHub issues](https://img.shields.io/github/issues/sekka1/docker-s3cmd.svg)](https://github.com/sekka1/docker-s3cmd/issues)
+[![Twitter](https://img.shields.io/twitter/url/https/github.com/sekka1/docker-s3cmd.svg?style=social)](https://twitter.com/intent/tweet?text=S3cmd%20in%20a%20%40Docker%20container:&url=https://github.com/sekka1/docker-s3cmd)
+[![Docker Pulls](https://img.shields.io/docker/pulls/garland/docker-s3cmd.svg)](https://hub.docker.com/r/garland/docker-s3cmd/)
+[![Docker Stars](https://img.shields.io/docker/stars/garland/docker-s3cmd.svg)](https://hub.docker.com/r/garland/docker-s3cmd/)
 
 
 # Supported tags and respective `Dockerfile` links
 
-- [`0.1` (*0.1/Dockerfile*)](https://github.com/zambien/docker-s3cmd/blob/master/0.1/Dockerfile)
+- [`0.1` (*0.1/Dockerfile*)](https://github.com/sekka1/docker-s3cmd/blob/master/0.1/Dockerfile)
 
 
 # Description
@@ -21,7 +21,7 @@ a container.
 
 Using [Alpine linux](https://hub.docker.com/_/alpine/).  This image is 31MB.
 
-You can find an automated build of this container on the Docker Hub: https://hub.docker.com/r/zambien/docker-s3cmd/
+You can find an automated build of this container on the Docker Hub: https://hub.docker.com/r/garland/docker-s3cmd/
 
 # Usage Instruction
 
@@ -35,7 +35,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
 
     AWS_KEY=<YOUR AWS KEY>
     AWS_SECRET=<YOUR AWS SECRET>
-    BUCKET=s3://zambien.public.bucket/database2/
+    BUCKET=s3://garland.public.bucket/database2/
     LOCAL_FILE=/tmp/database
 
     docker run \
@@ -44,7 +44,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
     --env cmd=sync-local-to-s3 \
     --env DEST_S3=${BUCKET}  \
     -v ${LOCAL_FILE}:/opt/src \
-    zambien/docker-s3cmd
+    garland/docker-s3cmd
 
 * Change `LOCAL_FILE` to file/folder you want to upload to S3
 
@@ -52,7 +52,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
 
     AWS_KEY=<YOUR AWS KEY>
     AWS_SECRET=<YOUR AWS SECRET>
-    BUCKET=s3://zambien.public.bucket/database
+    BUCKET=s3://garland.public.bucket/database
     LOCAL_FILE=/tmp
 
     docker run \
@@ -61,7 +61,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
     --env cmd=sync-s3-to-local \
     --env SRC_S3=${BUCKET} \
     -v ${LOCAL_FILE}:/opt/dest \
-    zambien/docker-s3cmd
+    garland/docker-s3cmd
 
 * Change `LOCAL_FILE` to the file/folder where you want to download the files from S3 to the local computer
 
@@ -75,7 +75,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
     --env aws_secret=${AWS_SECRET} \
     --env cmd=interactive \
     -v /:/opt/dest \
-    zambien/docker-s3cmd /bin/sh
+    garland/docker-s3cmd /bin/sh
 
 Then execute the `main.sh` script to setup the s3cmd config file
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 docker-s3cmd
 ============
-[![GitHub forks](https://img.shields.io/github/forks/sekka1/docker-s3cmd.svg)](https://github.com/sekka1/docker-s3cmd/network)
-[![GitHub stars](https://img.shields.io/github/stars/sekka1/docker-s3cmd.svg)](https://github.com/sekka1/docker-s3cmd/stargazers)
-[![GitHub issues](https://img.shields.io/github/issues/sekka1/docker-s3cmd.svg)](https://github.com/sekka1/docker-s3cmd/issues)
-[![Twitter](https://img.shields.io/twitter/url/https/github.com/sekka1/docker-s3cmd.svg?style=social)](https://twitter.com/intent/tweet?text=S3cmd%20in%20a%20%40Docker%20container:&url=https://github.com/sekka1/docker-s3cmd)
-[![Docker Pulls](https://img.shields.io/docker/pulls/garland/docker-s3cmd.svg)](https://hub.docker.com/r/garland/docker-s3cmd/)
-[![Docker Stars](https://img.shields.io/docker/stars/garland/docker-s3cmd.svg)](https://hub.docker.com/r/garland/docker-s3cmd/)
+[![GitHub forks](https://img.shields.io/github/forks/zambien/docker-s3cmd.svg)](https://github.com/zambien/docker-s3cmd/network)
+[![GitHub stars](https://img.shields.io/github/stars/zambien/docker-s3cmd.svg)](https://github.com/zambien/docker-s3cmd/stargazers)
+[![GitHub issues](https://img.shields.io/github/issues/zambien/docker-s3cmd.svg)](https://github.com/zambien/docker-s3cmd/issues)
+[![Twitter](https://img.shields.io/twitter/url/https/github.com/zambien/docker-s3cmd.svg?style=social)](https://twitter.com/intent/tweet?text=S3cmd%20in%20a%20%40Docker%20container:&url=https://github.com/zambien/docker-s3cmd)
+[![Docker Pulls](https://img.shields.io/docker/pulls/zambien/docker-s3cmd.svg)](https://hub.docker.com/r/zambien/docker-s3cmd/)
+[![Docker Stars](https://img.shields.io/docker/stars/zambien/docker-s3cmd.svg)](https://hub.docker.com/r/zambien/docker-s3cmd/)
 
 
 # Supported tags and respective `Dockerfile` links
 
-- [`0.1` (*0.1/Dockerfile*)](https://github.com/sekka1/docker-s3cmd/blob/master/0.1/Dockerfile)
+- [`0.1` (*0.1/Dockerfile*)](https://github.com/zambien/docker-s3cmd/blob/master/0.1/Dockerfile)
 
 
 # Description
@@ -21,7 +21,7 @@ a container.
 
 Using [Alpine linux](https://hub.docker.com/_/alpine/).  This image is 31MB.
 
-You can find an automated build of this container on the Docker Hub: https://hub.docker.com/r/garland/docker-s3cmd/
+You can find an automated build of this container on the Docker Hub: https://hub.docker.com/r/zambien/docker-s3cmd/
 
 # Usage Instruction
 
@@ -35,7 +35,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
 
     AWS_KEY=<YOUR AWS KEY>
     AWS_SECRET=<YOUR AWS SECRET>
-    BUCKET=s3://garland.public.bucket/database2/
+    BUCKET=s3://zambien.public.bucket/database2/
     LOCAL_FILE=/tmp/database
 
     docker run \
@@ -44,7 +44,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
     --env cmd=sync-local-to-s3 \
     --env DEST_S3=${BUCKET}  \
     -v ${LOCAL_FILE}:/opt/src \
-    garland/docker-s3cmd
+    zambien/docker-s3cmd
 
 * Change `LOCAL_FILE` to file/folder you want to upload to S3
 
@@ -52,7 +52,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
 
     AWS_KEY=<YOUR AWS KEY>
     AWS_SECRET=<YOUR AWS SECRET>
-    BUCKET=s3://garland.public.bucket/database
+    BUCKET=s3://zambien.public.bucket/database
     LOCAL_FILE=/tmp
 
     docker run \
@@ -61,7 +61,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
     --env cmd=sync-s3-to-local \
     --env SRC_S3=${BUCKET} \
     -v ${LOCAL_FILE}:/opt/dest \
-    garland/docker-s3cmd
+    zambien/docker-s3cmd
 
 * Change `LOCAL_FILE` to the file/folder where you want to download the files from S3 to the local computer
 
@@ -75,7 +75,7 @@ If access for your instance, task, etc. is configured through an IAM role you ma
     --env aws_secret=${AWS_SECRET} \
     --env cmd=interactive \
     -v /:/opt/dest \
-    garland/docker-s3cmd /bin/sh
+    zambien/docker-s3cmd /bin/sh
 
 Then execute the `main.sh` script to setup the s3cmd config file
 

--- a/files/main.sh
+++ b/files/main.sh
@@ -9,13 +9,14 @@ S3CMD_PATH=/opt/s3cmd/s3cmd
 # Check for required parameters
 #
 if [ -z "${aws_key}" ]; then
-    echo "ERROR: The environment variable key is not set."
-    exit 1
+    echo "The environment variable key is not set. Attempting to create empty creds file to use role."
+    aws_key=""
 fi
 
 if [ -z "${aws_secret}" ]; then
-    echo "ERROR: The environment variable secret is not set."
-    exit 1
+    echo "The environment variable secret is not set."
+    aws_secret=""
+    security_token=""
 fi
 
 if [ -z "${cmd}" ]; then
@@ -27,8 +28,12 @@ fi
 # Replace key and secret in the /.s3cfg file with the one the user provided
 #
 echo "" >> /.s3cfg
-echo "access_key=${aws_key}" >> /.s3cfg
-echo "secret_key=${aws_secret}" >> /.s3cfg
+echo "access_key = ${aws_key}" >> /.s3cfg
+echo "secret_key = ${aws_secret}" >> /.s3cfg
+
+if [ -z "${security_token}" ]; then
+    echo "security_token = ${aws_security_token}" >> /.s3cfg
+fi
 
 #
 # Add region base host if it exist in the env vars


### PR DESCRIPTION
Hello,

Thank you for making this image available to the community.

When using this module I found it didn't quite fit my requirements.  Generally I like to use IAM roles where possible so that my long lived credentials aren't sitting on a filesystem somewhere.  This change allows you to use docker-s3cmd with two different authentication scenarios.

1.  Key, Secret, AND session token.  This allows use of STS so you are only passing short lived information.
2.  No inputs.  If your instance has an IAM role the access is passed on to the container automatically.

Please review and let me know.  I have tested both scenarios and ended up settling on the IAM role approach as that feels like a better architecture.